### PR TITLE
Many small fixes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,21 @@
 FROM debian:stretch
 
 RUN apt-get update && \
-    apt-get install -y --force-yes --no-install-recommends \
+    apt-get install -y --no-install-recommends \
         locales \
         icedtea-plugin && \
+    dpkg-reconfigure locales && \
+    locale-gen C.UTF-8 && \
+    /usr/sbin/update-locale LANG=C.UTF-8 && \
+    echo 'en_CA.UTF-8 UTF-8' >> /etc/locale.gen && \
+    locale-gen && \
+    apt purge locales -y && \
+    apt autoremove -y && \
     apt clean
+
+ENV LC_ALL C.UTF-8
+ENV LANG en_CA.UTF-8
+ENV LANGUAGE en_CA.UTF-8
 
 ADD https://cheminotjws.etsmtl.ca/ChemiNot.jnlp /opt/ChemiNot.jnlp
 


### PR DESCRIPTION
**Removing `--force-yes`. And install locales.**
- Why removing `--force-yes` for `apt-install` according apt-get man ? :

```
--force-yes
           Force yes; this is a dangerous option that will cause apt to continue without prompting if it is doing something potentially harmful. It should not be used except in very special situations.
           Using force-yes can potentially destroy your system! Configuration Item: APT::Get::force-yes. This is deprecated and replaced by --allow-downgrades, --allow-remove-essential,
           --allow-change-held-packages in 1.1.
```
- Configured`locales` could be used to interpret french accent like `é` from
  stdout logs and JAVA gui. Example :

`Lien avec le serveur ?tabli.` ---> `Lien avec le serveur établi.`
- Note : Removing locales from same `RUN` save exactly 12 MB.
- Note2 : Autoremove will remove `libc-l10n` that came with `locales` but
  this package will be deleted. Autoremove will save another 4MB.
